### PR TITLE
Open Data Kit now only goes by ODK

### DIFF
--- a/docs/accueil.md
+++ b/docs/accueil.md
@@ -6,7 +6,7 @@ sidebar_position: 1
 :::info Avertissement
 Ce site et le dépot GIT associé sont une initiative de géomaticiens du réseau des Conservatoires d'Epsaces Naturels.
 Il fait la promotion d'ODK pour le mise en oeuvre des formulaires présentés et partagés mais est totalement indépendant du projet ODK.
-Les formulaires proposés ici sont mis en oeuvre par des utilisateurs de la solution et en rien par l'équipe de GetODK
+Les formulaires proposés ici sont mis en oeuvre par des utilisateurs de la solution et en rien par l'équipe de ODK
 :::
 ## Vitrine des formulaires XLSForm mis en œuvre pour la conservation de la nature
 

--- a/docs/odk.md
+++ b/docs/odk.md
@@ -1,15 +1,15 @@
 ---
-title: Open Data Kit
+title: ODK
 sidebar_position: 3
 ---
 
 :::info Avertissement
 Ce site et le dépôt Git associé sont une initiative de géomaticiens du [réseau des Conservatoires d'Espaces Naturels](https://reseau-cen.org/).
 Il promeut ODK pour le mise en œuvre des formulaires qui y sont présentés et partagés mais est totalement indépendant du projet ODK.
-Les formulaires proposés ici sont mis en œuvre par des utilisateurs de la solution et en rien par l'équipe de GetODK
+Les formulaires proposés ici sont mis en œuvre par des utilisateurs de la solution et en rien par l'équipe de ODK.
 :::
 
-# ODK - Open Data Kit
+# ODK
 C'est l'outil que nous utilisons depuis 2015 pour servir les formulaires sur nos téléphones de terrain. 
 
 ## Présentation de l'outil

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -126,7 +126,7 @@ const config = {
                 href: 'https://forum.getodk.org/',
               },
               {
-                label: 'GetODK',
+                label: 'ODK',
                 href: 'https://www.getodk.org/',
               }
             ],

--- a/src/components/HomepageFeatures/index.js
+++ b/src/components/HomepageFeatures/index.js
@@ -18,7 +18,7 @@ const FeatureList = [
     Svg: require('@site/static/img/odk.svg').default,
     description: (
       <>
-        ODK (<a href="https://getodk.org">Open Data Kit</a>) est un outil opensource de génération de formulaires pour téléphones Android.
+        <a href="https://getodk.org">ODK</a> est un outil opensource de génération de formulaires pour téléphones Android.
         D&apos;autres outils utilisent XLSForm mais ODK est celui que nous utilisons.
       </>
     ),


### PR DESCRIPTION
Thanks so much for putting this site together!

In the same way that "International Business Machines" is now just "IBM", "Open Data Kit" is now just "ODK". You can also refer to Get ODK as ODK if it makes the writing clearer because we have a business alias (aka DBA) of ODK.

This pull request replaces every user-facing "Open Data Kit" with "ODK".

I ran this locally to confirm that everything works as expected, mais mon français n'est pas très bon, so please review before merging.